### PR TITLE
change flutter version in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
           java-version: '12.x'
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '1.8.4'
+          flutter-version: '1.7.8+hotfix.4'
           channel: 'beta'
       - run: flutter pub get
       - run: flutter test


### PR DESCRIPTION
Change the flutter version in README from 1.8.4 to 1.7.8+hotfix.4 to keep it consistent with the first example and also avoid confusion because 1.8.4 beta does not exist (which will cause a http error if someone copy the code as is).