### PR TITLE
Add master channel

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -150,6 +150,7 @@ interface IFlutterChannel {
   beta: string;
   dev: string;
   stable: string;
+  master: string;
 }
 
 interface IFlutterRelease {


### PR DESCRIPTION
The Master channel option is missing. 

I'm not really experienced in node and javascript, but I guess that this is the only thing we have to do to add the master channel to the list right?