### PR TITLE
might be interesting to add dart SDK to path

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -62,7 +62,7 @@ export async function getFlutter(
 
   core.exportVariable('FLUTTER_HOME', toolPath);
   core.addPath(path.join(toolPath, 'bin'));
-  core.addPath(path.join(toolPath, 'bin/cache/dart-sdk/bin'));
+  core.addPath(path.join(toolPath, 'bin', 'cache', 'dart-sdk', 'bin'));
 }
 
 function osName(): string {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -62,6 +62,7 @@ export async function getFlutter(
 
   core.exportVariable('FLUTTER_HOME', toolPath);
   core.addPath(path.join(toolPath, 'bin'));
+  core.addPath(path.join(toolPath, 'bin/cache/dart-sdk'));
 }
 
 function osName(): string {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -62,7 +62,7 @@ export async function getFlutter(
 
   core.exportVariable('FLUTTER_HOME', toolPath);
   core.addPath(path.join(toolPath, 'bin'));
-  core.addPath(path.join(toolPath, 'bin/cache/dart-sdk'));
+  core.addPath(path.join(toolPath, 'bin/cache/dart-sdk/bin'));
 }
 
 function osName(): string {


### PR DESCRIPTION
Adding Flutter bin to the path doesn't expose the dart SDK which many people might be interested in using. For example, `dartdoc` for documentation generation.

Currently, one might be able to call the dart SDK by `$FLUTTER_HOME/bin/cache/dart-sdk/dart`, but it would be interesting if that can be simplified to just `dart` or `dartdoc`.