### PR TITLE
Update readme with info how to build web application.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,16 @@ jobs:
       - run: flutter build apk
 ```
 
+Web build:
+
+```yaml
+steps:
+- uses: actions/checkout@v1
+- uses: subosito/flutter-action@v1
+  with:
+    channel: 'stable' # or: 'dev' or 'beta'
+- name: Build Web
+  env:
+    FLUTTER_WEB: 'true'
+  run: flutter build web     
+```


### PR DESCRIPTION
I know that's not strictly related to this action implementation but I would like to know that because according to [official documentation](https://flutter.dev/docs/get-started/web#set-up) this won't work on CI/CD:
```
run: |
   flutter config --enable-web
   flutter build web
```
It will throw an error:
```
"build web" is not currently supported.
```
References:
- [feature enable-web](https://github.com/flutter/flutter/blob/18f38cd45bee65931c28433c2071d48570b62b1b/packages/flutter_tools/lib/src/features.dart#L78)
- [feature environmentOverride explanation](https://github.com/flutter/flutter/blob/18f38cd45bee65931c28433c2071d48570b62b1b/packages/flutter_tools/lib/src/features.dart#L188)