### PR TITLE
feat: add problem matcher

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6071,6 +6071,7 @@ function getFlutter(version, channel) {
         core.exportVariable('FLUTTER_HOME', toolPath);
         core.addPath(path.join(toolPath, 'bin'));
         core.addPath(path.join(toolPath, 'bin', 'cache', 'dart-sdk', 'bin'));
+        core.info(`##[add-matcher]${path.join(__dirname, '../problem-matcher.json')}`);
     });
 }
 exports.getFlutter = getFlutter;

--- a/problem-matcher.json
+++ b/problem-matcher.json
@@ -1,0 +1,18 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "flutter-analyze-matcher",
+            "pattern": [
+                {
+                    "regexp": "^\\s+(.+?)\\s+\\W\\s+(.+?)\\s+\\W\\s+(.+?):(\\d+):(\\d+)\\s+\\W\\s+(.+)$",
+                    "severity": 1,
+                    "message": 2,
+                    "file": 3,
+                    "line": 4,
+                    "column": 5,
+                    "code": 6
+                }
+            ]
+        }
+    ]
+}

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -68,6 +68,8 @@ export async function getFlutter(
   core.exportVariable('FLUTTER_HOME', toolPath);
   core.addPath(path.join(toolPath, 'bin'));
   core.addPath(path.join(toolPath, 'bin', 'cache', 'dart-sdk', 'bin'));
+
+  core.info(`##[add-matcher]${path.join(__dirname, '../problem-matcher.json')}`);
 }
 
 function osName(): string {


### PR DESCRIPTION
This feature would enable GitHub to automatically turn issues reported by `flutter analyze` into annotations via [problem matchers](https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md)

I haven't been able to get it working yet and need to throw in the towel for now, GitHub is currently reporting in my test runs:

> Removing issue matcher 'flutter-analyze-matcher'. Matcher failed 3 times. Error: The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.

The official `setup-*` actions all come with these for the standard lint tools in their stacks