### PR TITLE
add example to build for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,28 @@ jobs:
     - run: flutter build web
 ```
 
+Build for Windows and upload artifact:
+
+```yaml
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '12.x'
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: dev
+      - run: flutter config --enable-windows-desktop
+      - run: flutter create .
+      - run: flutter build windows
+      - uses: actions/upload-artifact@master
+        with:
+          name: windows
+          path: build\windows\runner\Release
+```
+
 Use latest release for particular channel:
 
 ```yaml


### PR DESCRIPTION
add example script which will build a windows executable and also upload it to action artifacts

Is      `  - uses: actions/setup-java@v1 ` required?

I tried this on my own repository and to my surprise it actually worked.