### PR TITLE
Export PUB_CACHE if it is not in env

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -123,9 +123,14 @@ function getFlutter(version, channel) {
             toolPath = yield tc.cacheDir(sdkDir, 'flutter', cleanver);
         }
         core.exportVariable('FLUTTER_ROOT', toolPath);
+        let pubCachePath = process.env['PUB_CACHE'] || '';
+        if (!pubCachePath) {
+            pubCachePath = path.join(toolPath, '.pub-cache');
+            core.exportVariable('PUB_CACHE', pubCachePath);
+        }
         core.addPath(path.join(toolPath, 'bin'));
         core.addPath(path.join(toolPath, 'bin', 'cache', 'dart-sdk', 'bin'));
-        core.addPath(path.join(toolPath, '.pub-cache', 'bin'));
+        core.addPath(path.join(pubCachePath, 'bin'));
         if (useMaster) {
             yield exec.exec('flutter', ['channel', 'master']);
             yield exec.exec('flutter', ['upgrade']);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -46,9 +46,17 @@ export async function getFlutter(
   }
 
   core.exportVariable('FLUTTER_ROOT', toolPath);
+
+  let pubCachePath = process.env['PUB_CACHE'] || '';
+
+  if (!pubCachePath) {
+    pubCachePath = path.join(toolPath, '.pub-cache');
+    core.exportVariable('PUB_CACHE', pubCachePath);
+  }
+
   core.addPath(path.join(toolPath, 'bin'));
   core.addPath(path.join(toolPath, 'bin', 'cache', 'dart-sdk', 'bin'));
-  core.addPath(path.join(toolPath, '.pub-cache', 'bin'));
+  core.addPath(path.join(pubCachePath, 'bin'));
 
   if (useMaster) {
     await exec.exec('flutter', ['channel', 'master']);


### PR DESCRIPTION
Fixes #89 

Export `PUB_CACHE` if it is not configured before calling the action.
This ensures that flutter and dart use the same cache.
It also enables other tools to use this official Dart env variable.