### PR TITLE
Fix the endpoint for flutter releases

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -231,7 +231,7 @@ exports.determineVersion = exports.getPlatform = exports.storageUrl = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const httpm = __importStar(__nccwpck_require__(9925));
 const semver = __importStar(__nccwpck_require__(1383));
-exports.storageUrl = 'https://storage.googleapis.com/flutter_infra/releases';
+exports.storageUrl = 'https://storage.googleapis.com/flutter_infra_release/releases';
 function getPlatform() {
     const platform = process.platform;
     if (platform == 'win32') {

--- a/src/release.ts
+++ b/src/release.ts
@@ -3,7 +3,7 @@ import * as httpm from '@actions/http-client';
 import * as semver from 'semver';
 
 export const storageUrl =
-  'https://storage.googleapis.com/flutter_infra/releases';
+  'https://storage.googleapis.com/flutter_infra_release/releases';
 
 interface IFlutterData {
   channel: string;


### PR DESCRIPTION
It seems like the previous endpoint broke a few minutes ago so here's a quick pull request that fixes the issue.