### PR TITLE
Fix temp folder handling on windows

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,12 @@
 name: Main workflow
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
 jobs:
   test_channel:
     runs-on: ${{ matrix.operating-system }}

--- a/setup.sh
+++ b/setup.sh
@@ -52,11 +52,17 @@ download_archive() {
 
   curl --connect-timeout 15 --retry 5 $archive_url >$archive_local
 
+  # Create the target folder
+  mkdir -p "$2"
+
   if [[ $archive_name == *zip ]]; then
     unzip -q -o "$archive_local" -d "$RUNNER_TEMP"
-    shopt -s dotglob
-    mv ${RUNNER_TEMP}/flutter/* "$2"
-    shopt -u dotglob
+    # Remove the folder again so that the move command can do a simple rename
+    # instead of moving the content into the target folder.
+    # This is a little bit of a hack since the "mv --no-target-directory"
+    # linux option is not available here
+    rm -r "$2"
+    mv ${RUNNER_TEMP}/flutter "$2"
   else
     tar xf "$archive_local" -C "$2" --strip-components=1
   fi
@@ -89,8 +95,6 @@ if [[ $OS_NAME == windows ]]; then
 else
   PUB_CACHE="${HOME}/.pub-cache"
 fi
-
-mkdir -p "$SDK_CACHE"
 
 if [[ ! -x "${SDK_CACHE}/bin/flutter" ]]; then
   if [[ $CHANNEL == master ]]; then


### PR DESCRIPTION
Follow up for #132 

Something with the globing seems not work but not sure exactly. Now using a simple way of ensure that the target folder never exists when calling `mv` so that it behaves as a rename instead of a move into. The folder still needs to be created first so that parent folders (in case of a custom cache path) are created.

Added a .gitignore

Only run on push/pr on main branch to avoid duplicate builds and overuse of macos-runners.