### PR TITLE
Added missing parameter for cache-key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
   using: 'composite'
   steps:
     - id: flutter-action
-      run: $GITHUB_ACTION_PATH/setup.sh -p -c '${{ inputs.cache-path }}' -n '${{ inputs.flutter-version }}' -a '${{ inputs.architecture }}' ${{ inputs.channel }}
+      run: $GITHUB_ACTION_PATH/setup.sh -p -c '${{ inputs.cache-path }}' -k '${{ inputs.cache-key }}' -n '${{ inputs.flutter-version }}' -a '${{ inputs.architecture }}' ${{ inputs.channel }}
       shell: bash
     - if: ${{ inputs.cache == 'true' }}
       uses: actions/cache@v3


### PR DESCRIPTION
Right now the `cache-key` parameter at the action level doesn't work, because the value is not propagated to the bash script.

This PR adds this missing parameter to be able to customize the cache key value.