### PR TITLE
feat: Adds timeout for cache download

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,5 +51,7 @@ runs:
       with:
         path: ${{ steps.flutter-action.outputs.CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.CACHE-KEY }}
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: "2"
     - run: $GITHUB_ACTION_PATH/setup.sh -c '${{ steps.flutter-action.outputs.CACHE-PATH }}' -n '${{ steps.flutter-action.outputs.VERSION }}' -a '${{ steps.flutter-action.outputs.ARCHITECTURE }}' ${{ steps.flutter-action.outputs.CHANNEL }}
       shell: bash


### PR DESCRIPTION
Fix for https://github.com/subosito/flutter-action/issues/186

Added `SEGMENT_DOWNLOAD_TIMEOUT_MINS` with parameter set as 2 minutes for download of cache

Link to relevant documentation: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cache-segment-restore-timeout