### PR TITLE
The example yaml code need to be modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ Use outputs from `flutter-action`:
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
 - id: flutter-action
+- uses: actions/checkout@v3
   uses: subosito/flutter-action@v2
   with:
     channel: 'stable'


### PR DESCRIPTION
```
  check-settings:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - id: flutter-action
      - uses: subosito/flutter-action@v2
        with:
          channel: 'stable'
      - run: |
          echo CACHE-PATH=${{ steps.flutter-action.outputs.CACHE-PATH }}
          echo CACHE-KEY=${{ steps.flutter-action.outputs.CACHE-KEY }}
          echo CHANNEL=${{ steps.flutter-action.outputs.CHANNEL }}
          echo VERSION=${{ steps.flutter-action.outputs.VERSION }}
          echo ARCHITECTURE=${{ steps.flutter-action.outputs.ARCHITECTURE }}
        shell: bash
```
This is the last code in README.md.

When you run this script, github action throw error. 
> every step must define a `uses` or `run` key

If you swap the order of 'id' and 'uses', you can solve this.