### PR TITLE
Set architecture options from runner's architecture

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,6 +31,9 @@ jobs:
         channel: ${{ matrix.channel }}
     - name: Echo outputs
       run: |
+        echo RUNNER-OS=${{ runner.os }}
+        echo RUNNER-ARCH=${{ runner.arch }}
+
         echo CACHE-PATH=${{ steps.flutter-action.outputs.CACHE-PATH }}
         echo CACHE-KEY=${{ steps.flutter-action.outputs.CACHE-KEY }}
         echo CHANNEL=${{ steps.flutter-action.outputs.CHANNEL }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,7 @@ jobs:
   lint_shellcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ludeeus/action-shellcheck@master
   test_channel:
     runs-on: ${{ matrix.operating-system }}
@@ -24,7 +24,7 @@ jobs:
           - operating-system: ubuntu-latest
             channel: main
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - id: flutter-action
       uses: ./
       with:
@@ -50,7 +50,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       with:
         channel: stable
@@ -63,7 +63,7 @@ jobs:
   test_print_output:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: ./setup.sh -t -p                        | grep 'stable'
       shell: bash
     - run: ./setup.sh -t -p                        | grep '3.7.7'

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
       run: $GITHUB_ACTION_PATH/setup.sh -p -c '${{ inputs.cache-path }}' -k '${{ inputs.cache-key }}' -n '${{ inputs.flutter-version }}' -a '${{ inputs.architecture }}' ${{ inputs.channel }}
       shell: bash
     - if: ${{ inputs.cache == 'true' }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.flutter-action.outputs.CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.CACHE-KEY }}-${{ hashFiles('**/pubspec.lock') }}

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,7 @@ if ! check_command jq; then
 fi
 
 OS_NAME=$(echo "$RUNNER_OS" | awk '{print tolower($0)}')
+ARCH_NAME=$(echo "$RUNNER_ARCH" | awk '{print tolower($0)}')
 MANIFEST_BASE_URL="https://storage.googleapis.com/flutter_infra_release/releases"
 MANIFEST_JSON_PATH="releases_$OS_NAME.json"
 MANIFEST_URL="$MANIFEST_BASE_URL/$MANIFEST_JSON_PATH"
@@ -82,6 +83,8 @@ while getopts 'tc:k:pa:n:' flag; do
 	?) exit 2 ;;
 	esac
 done
+
+[[ -z $ARCH ]] && ARCH="$ARCH_NAME"
 
 ARR_CHANNEL=("${@:$OPTIND:1}")
 CHANNEL="${ARR_CHANNEL[0]}"


### PR DESCRIPTION
Apple silicon is now available. 

https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/

This makes it necessary in some cases to set arm64 for the architecture option.
There is already an option (Thanks!). However, in most cases x64 is used and the option is missed. Therefore, it is likely that users with Apple silicon will not realize that they need to configure arm64.

To solve the above problem, I added a process to get the appropriate architecture from `runner-arch` if the option is not set. 
Thanks for the great tool.