### PR TITLE
Improvements to caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ steps:
     cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:' # optional, change this to force refresh cache
     cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:' # optional, change this to specify the cache path
     pub-cache-key: 'flutter-pub:os:-:channel:-:version:-:arch:-:hash:' # optional, change this to force refresh cache of dart pub get dependencies
-    cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:' # optional, change this to specify the cache path
+    pub-cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:' # optional, change this to specify the cache path
     architecture: x64 # optional, x64 or arm64
 - run: flutter --version
 ```

--- a/README.md
+++ b/README.md
@@ -171,11 +171,13 @@ steps:
     cache: true
     cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:' # optional, change this to force refresh cache
     cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:' # optional, change this to specify the cache path
+    pub-cache-key: 'flutter-pub:os:-:channel:-:version:-:arch:-:hash:' # optional, change this to force refresh cache of dart pub get dependencies
+    cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:' # optional, change this to specify the cache path
     architecture: x64 # optional, x64 or arm64
 - run: flutter --version
 ```
 
-Note: `cache-key` and `cache-path` has support for several dynamic values:
+Note: `cache-key`, `pub-cache-key`, and `cache-path` has support for several dynamic values:
 
 - `:os:`
 - `:channel:`
@@ -199,5 +201,7 @@ steps:
     echo CHANNEL=${{ steps.flutter-action.outputs.CHANNEL }}
     echo VERSION=${{ steps.flutter-action.outputs.VERSION }}
     echo ARCHITECTURE=${{ steps.flutter-action.outputs.ARCHITECTURE }}
+    echo PUB-CACHE-PATH=${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
+    echo PUB-CACHE-KEY=${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}
   shell: bash
 ```

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
       run: $GITHUB_ACTION_PATH/setup.sh -p -c '${{ inputs.cache-path }}' -k '${{ inputs.cache-key }}' -n '${{ inputs.flutter-version }}' -a '${{ inputs.architecture }}' ${{ inputs.channel }}
       shell: bash
     - if: ${{ inputs.cache == 'true' }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.flutter-action.outputs.CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.CACHE-KEY }}-${{ hashFiles('**/pubspec.lock') }}

--- a/action.yml
+++ b/action.yml
@@ -16,11 +16,15 @@ inputs:
   cache:
     description: 'Cache the Flutter SDK'
     required: false
-    default: false
+    default: 'false'
   cache-key:
     description: 'Identifier for the Flutter SDK cache'
     required: false
     default: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
+  pub-cache-key:
+    description: 'Identifier for the Dart .pub-cache cache'
+    required: false
+    default: 'flutter-pub:os:-:channel:-:version:-:arch:-:hash:'
   cache-path:
     description: 'Flutter SDK cache path'
     required: false
@@ -40,21 +44,32 @@ outputs:
     value: '${{ steps.flutter-action.outputs.VERSION }}'
   ARCHITECTURE:
     value: '${{ steps.flutter-action.outputs.ARCHITECTURE }}'
+  PUB-CACHE-KEY:
+    value: '${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}'
+  PUB-CACHE-PATH:
+    value: '${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}'
 runs:
   using: 'composite'
   steps:
     - run: chmod +x $GITHUB_ACTION_PATH/setup.sh
       shell: bash
     - id: flutter-action
-      run: $GITHUB_ACTION_PATH/setup.sh -p -c '${{ inputs.cache-path }}' -k '${{ inputs.cache-key }}' -n '${{ inputs.flutter-version }}' -a '${{ inputs.architecture }}' ${{ inputs.channel }}
+      run: $GITHUB_ACTION_PATH/setup.sh -p -c '${{ inputs.cache-path }}' -k '${{ inputs.cache-key }}' -d '${{ inputs.pub-cache-key }}' -n '${{ inputs.flutter-version }}' -a '${{ inputs.architecture }}' ${{ inputs.channel }}
       shell: bash
     - if: ${{ inputs.cache == 'true' }}
       uses: actions/cache@v4
       with:
         path: ${{ steps.flutter-action.outputs.CACHE-PATH }}
-        key: ${{ steps.flutter-action.outputs.CACHE-KEY }}-${{ hashFiles('**/pubspec.lock') }}
+        key: ${{ steps.flutter-action.outputs.CACHE-KEY }}
         restore-keys: |
-          ${{ steps.flutter-action.outputs.CACHE-KEY }}-${{ hashFiles('**/pubspec.lock') }}
           ${{ steps.flutter-action.outputs.CACHE-KEY }}
+    - if: ${{ inputs.cache == 'true' }}
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
+        key: ${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}-${{ hashFiles('**/pubspec.lock') }}
+        restore-keys: |
+          ${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}-${{ hashFiles('**/pubspec.lock') }}
+          ${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}
     - run: $GITHUB_ACTION_PATH/setup.sh -c '${{ steps.flutter-action.outputs.CACHE-PATH }}' -n '${{ steps.flutter-action.outputs.VERSION }}' -a '${{ steps.flutter-action.outputs.ARCHITECTURE }}' ${{ steps.flutter-action.outputs.CHANNEL }}
       shell: bash

--- a/setup.sh
+++ b/setup.sh
@@ -94,6 +94,7 @@ CHANNEL="${ARR_CHANNEL[0]}"
 [[ -z $CACHE_PATH ]] && CACHE_PATH="$RUNNER_TEMP/flutter/:channel:-:version:-:arch:"
 [[ -z $CACHE_KEY ]] && CACHE_KEY="flutter-:os:-:channel:-:version:-:arch:-:hash:"
 [[ -z $PUB_CACHE_KEY ]] && PUB_CACHE_KEY="flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
+# Here we specifically use `PUB_CACHE` (and not `PUB_CACHE_PATH`), because `PUB_CACHE` is what dart (and flutter) looks for in the environment
 [[ -z $PUB_CACHE ]] && PUB_CACHE="$HOME/.pub-cache"
 
 if [[ "$TEST_MODE" == true ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -66,15 +66,17 @@ download_archive() {
 
 CACHE_PATH=""
 CACHE_KEY=""
+PUB_CACHE_KEY=""
 PRINT_ONLY=""
 TEST_MODE=false
 ARCH=""
 VERSION=""
 
-while getopts 'tc:k:pa:n:' flag; do
+while getopts 'tc:k:d:pa:n:' flag; do
 	case "$flag" in
 	c) CACHE_PATH="$OPTARG" ;;
 	k) CACHE_KEY="$OPTARG" ;;
+	d) PUB_CACHE_KEY="$OPTARG" ;;
 	p) PRINT_ONLY=true ;;
 	t) TEST_MODE=true ;;
 	a) ARCH="$(echo "$OPTARG" | awk '{print tolower($0)}')" ;;
@@ -91,7 +93,8 @@ CHANNEL="${ARR_CHANNEL[0]}"
 [[ -z $ARCH ]] && ARCH=x64
 [[ -z $CACHE_PATH ]] && CACHE_PATH="$RUNNER_TEMP/flutter/:channel:-:version:-:arch:"
 [[ -z $CACHE_KEY ]] && CACHE_KEY="flutter-:os:-:channel:-:version:-:arch:-:hash:"
-[[ -z $PUB_CACHE ]] && PUB_CACHE="$CACHE_PATH/.pub-cache"
+[[ -z $PUB_CACHE_KEY ]] && PUB_CACHE_KEY="flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
+[[ -z $PUB_CACHE ]] && PUB_CACHE="$HOME/.pub-cache"
 
 if [[ "$TEST_MODE" == true ]]; then
 	RELEASE_MANIFEST=$(cat "$(dirname -- "${BASH_SOURCE[0]}")/test/$MANIFEST_JSON_PATH")
@@ -128,6 +131,7 @@ expand_key() {
 }
 
 CACHE_KEY=$(expand_key "$CACHE_KEY")
+PUB_CACHE_KEY=$(expand_key "$PUB_CACHE_KEY")
 CACHE_PATH=$(expand_key "$(transform_path "$CACHE_PATH")")
 
 if [[ "$PRINT_ONLY" == true ]]; then
@@ -143,6 +147,8 @@ if [[ "$PRINT_ONLY" == true ]]; then
 		echo "ARCHITECTURE=$info_architecture"
 		echo "CACHE-KEY=$CACHE_KEY"
 		echo "CACHE-PATH=$CACHE_PATH"
+		echo "PUB-CACHE-KEY=$PUB_CACHE_KEY"
+		echo "PUB-CACHE-PATH=$PUB_CACHE"
 		exit 0
 	fi
 
@@ -152,6 +158,8 @@ if [[ "$PRINT_ONLY" == true ]]; then
 		echo "ARCHITECTURE=$info_architecture"
 		echo "CACHE-KEY=$CACHE_KEY"
 		echo "CACHE-PATH=$CACHE_PATH"
+		echo "PUB-CACHE-KEY=$PUB_CACHE_KEY"
+		echo "PUB-CACHE-PATH=$PUB_CACHE"
 	} >>"$GITHUB_OUTPUT"
 
 	exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -91,6 +91,7 @@ CHANNEL="${ARR_CHANNEL[0]}"
 [[ -z $ARCH ]] && ARCH=x64
 [[ -z $CACHE_PATH ]] && CACHE_PATH="$RUNNER_TEMP/flutter/:channel:-:version:-:arch:"
 [[ -z $CACHE_KEY ]] && CACHE_KEY="flutter-:os:-:channel:-:version:-:arch:-:hash:"
+[[ -z $PUB_CACHE ]] && PUB_CACHE="$CACHE_PATH/.pub-cache"
 
 if [[ "$TEST_MODE" == true ]]; then
 	RELEASE_MANIFEST=$(cat "$(dirname -- "${BASH_SOURCE[0]}")/test/$MANIFEST_JSON_PATH")
@@ -171,11 +172,11 @@ fi
 
 {
 	echo "FLUTTER_ROOT=$CACHE_PATH"
-	echo "PUB_CACHE=$CACHE_PATH/.pub-cache"
+	echo "PUB_CACHE=$PUB_CACHE"
 } >>"$GITHUB_ENV"
 
 {
 	echo "$CACHE_PATH/bin"
 	echo "$CACHE_PATH/bin/cache/dart-sdk/bin"
-	echo "$CACHE_PATH/.pub-cache/bin"
+	echo "$PUB_CACHE/bin"
 } >>"$GITHUB_PATH"


### PR DESCRIPTION
- Update actions/cache to v4 to suppress warnings about old node.js versions
- Allow users to set `PUB_CACHE` before invoking the action to control where the .pub-cache directory lives
- Cache the .pub-cache directory separately from the flutter installation, since the former will change often and the latter will change rarely -- this reduces the amount of cache churn / space used up in the cache until the data expires