### PR TITLE
fix: specify pub cache path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Flutter SDK cache path'
     required: false
     default: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:'
+  pub-cache-path:
+    description: 'Flutter pub cache path'
+    required: false
+    default: 'default'
   architecture:
     description: 'The architecture of Flutter SDK executable (x64 or arm64)'
     required: false
@@ -54,7 +58,7 @@ runs:
     - run: chmod +x $GITHUB_ACTION_PATH/setup.sh
       shell: bash
     - id: flutter-action
-      run: $GITHUB_ACTION_PATH/setup.sh -p -c '${{ inputs.cache-path }}' -k '${{ inputs.cache-key }}' -d '${{ inputs.pub-cache-key }}' -n '${{ inputs.flutter-version }}' -a '${{ inputs.architecture }}' ${{ inputs.channel }}
+      run: $GITHUB_ACTION_PATH/setup.sh -p -c '${{ inputs.cache-path }}' -k '${{ inputs.cache-key }}' -d '${{ inputs.pub-cache-path }}' -l '${{ inputs.pub-cache-key }}' -n '${{ inputs.flutter-version }}' -a '${{ inputs.architecture }}' ${{ inputs.channel }}
       shell: bash
     - if: ${{ inputs.cache == 'true' }}
       uses: actions/cache@v4


### PR DESCRIPTION
Currently, specifying a `pub-cache-path` like in the README doesn't do anything. This PR fixes this by adding the input. I've set up the priority like this:

1. If the environmental variable `PUB_CACHE` is specified before using the action, continue using it. 
2. If `PUB_CACHE_PATH` is specified and is not the default value, then use it.
3. Otherwise, use the defaults set by Dart as per https://dart.dev/tools/pub/environment-variables

In every case, the value will be re-exported as the environment variable by the name of `PUB_CACHE`, written to the action's output in the variable `PUB-CACHE-PATH`, and its `bin` sub-directory appended to `PATH`

resolves https://github.com/subosito/flutter-action/issues/278
resolves https://github.com/subosito/flutter-action/issues/277