### PR TITLE
chore: Add m1 chip macos machine

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - setup.sh
       - action.yml
+      - .github/workflows/workflow.yml
 jobs:
   lint_shellcheck:
     runs-on: ubuntu-latest
@@ -18,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+        operating-system: [ubuntu-latest, windows-latest, macos-latest, macos-13, macos-14]
         channel: [stable, beta, master]
         include:
           - operating-system: ubuntu-latest
@@ -48,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+        operating-system: [ubuntu-latest, windows-latest, macos-latest, macos-13, macos-14]
     steps:
     - uses: actions/checkout@v4
     - uses: ./


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
With `macos-14`, the m1 environment (arm64 environment) is available.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Currently, `macos-latest` refers to `macos-12`.
After Q2 Since FY24 (April - June 2024), `macos-latest` will refer to `macos-14`.

For this reason, I have added `[macos-latest, macos-13, macos-14]` to the list to be tested; once macos-latest references macos-14, I will create a PR to change the list to `[macos-latest, macos-13]`.
This change allows us to check that flutter-action works in both intel mac and m1 mac environments.