### PR TITLE
Remove macos-14 from matrix

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -53,16 +53,16 @@ jobs:
           echo ARCHITECTURE=${{ steps.flutter-action.outputs.ARCHITECTURE }}
         shell: bash
       - run: dart --version
-        if: ${{ matrix.dry-run != 'true' }}
+        if: ${{ !matrix.dry-run }}
         shell: bash
       - run: flutter --version
-        if: ${{ matrix.dry-run != 'true' }}
+        if: ${{ !matrix.dry-run }}
         shell: bash
       - run: "! dart --version"
-        if: ${{ matrix.dry-run == 'true' }}
+        if: ${{ matrix.dry-run }}
         shell: bash
       - run: "! flutter --version"
-        if: ${{ matrix.dry-run == 'true' }}
+        if: ${{ matrix.dry-run }}
         shell: bash
 
   test_cache:
@@ -108,7 +108,7 @@ jobs:
         shell: bash
 
   test_print_output:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - name: Clone repository

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         operating-system:
-          [ubuntu-latest, windows-latest, macos-latest, macos-13, macos-14]
+          [ubuntu-latest, windows-latest, macos-latest, macos-13]
         channel: [stable, beta, master]
         dry-run: [true, false]
         include:
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         operating-system:
-          [ubuntu-latest, windows-latest, macos-latest, macos-13, macos-14]
+          [ubuntu-latest, windows-latest, macos-latest, macos-13]
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
Remove the macos-14 designation from matrix because macos-latest is now macos-14.
The `test_print_output` is not updated to macos-latest because the test assumes that it works on intel mac.

https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/

ref: https://github.com/subosito/flutter-action/pull/281

---

Intended to be merged after https://github.com/subosito/flutter-action/pull/303. The CI fix and macos-14 removal can be done at the same time, but split because the main purpose of the PR is different.
