### PR TITLE
Support older yq versions

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -108,7 +108,7 @@ if [ -n "$VERSION_FILE" ]; then
 		exit 1
 	fi
 
-	VERSION="$(yq '.environment.flutter' "$VERSION_FILE")"
+	VERSION="$(yq eval '.environment.flutter' "$VERSION_FILE")"
 fi
 
 ARR_CHANNEL=("${@:$OPTIND:1}")


### PR DESCRIPTION
For some reason, Ubuntu has their latest version to [4.16.2](https://launchpad.net/~rmescandon/+archive/ubuntu/yq), and that version of yq doesn't use eval by default as it does with the newer versions.

https://mikefarah.gitbook.io/yq#notice-for-v4.x-versions-prior-to-4.18.1

Old 4.16.2:
```bash
~$ yq --version
yq (https://github.com/mikefarah/yq/) version 4.16.2

~$ yq '.environment.flutter' pubspec.yaml
Error: unknown command ".environment.flutter" for "yq"
Run 'yq --help' for usage.

~$ yq eval '.environment.flutter' pubspec.yaml 
3.24.4
```

New version
```bash
~$ yq --version
yq (https://github.com/mikefarah/yq/) version v4.44.2
~$ yq '.environment.flutter' pubspec.yaml 
3.24.4
~$ yq eval '.environment.flutter' pubspec.yaml 
3.24.4
```

One info, latest version of yq is able to be installed trough snap :/