### PR TITLE
feat: impl cache hit outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ steps:
       echo ARCHITECTURE=${{ steps.flutter-action.outputs.ARCHITECTURE }}
       echo PUB-CACHE-PATH=${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
       echo PUB-CACHE-KEY=${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}
+      echo CACHE-HIT=${{ steps.flutter-action.outputs.CACHE-HIT }}
 ```
 
 If you don't need to install Flutter and just want the outputs, you can use the
@@ -361,6 +362,7 @@ steps:
       echo ARCHITECTURE=${{ steps.flutter-action.outputs.ARCHITECTURE }}
       echo PUB-CACHE-PATH=${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
       echo PUB-CACHE-KEY=${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}
+      echo CACHE-HIT=${{ steps.flutter-action.outputs.CACHE-HIT }}
     shell: bash
 ```
 [Alif Rachmawadi]: https://github.com/subosito

--- a/action.yaml
+++ b/action.yaml
@@ -76,6 +76,9 @@ outputs:
   GIT_SOURCE:
     value: "${{ steps.flutter-action.outputs.GIT_SOURCE }}"
     description: Git source of Flutter SDK repository to clone
+  CACHE-HIT:
+    value: "${{ steps.cache-hit-pub.outputs.cache-hit }}"
+    description: Whether the Pub cache was a hit
 
 runs:
   using: composite
@@ -118,6 +121,7 @@ runs:
 
     - name: Cache pub dependencies
       uses: actions/cache@v4
+      id: cache-pub
       if: ${{ inputs.cache == 'true' }}
       with:
         path: ${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
@@ -125,6 +129,11 @@ runs:
         restore-keys: |
           ${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}-${{ hashFiles('**/pubspec.lock') }}
           ${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}
+
+    - name: Set pub cache hit outputs
+      id: cache-hit-pub
+      shell: bash
+      run: echo "cache-hit=${{ steps.cache-pub.outputs.cache-hit }}" >> "$GITHUB_OUTPUT"
 
     - name: Run setup script
       shell: bash


### PR DESCRIPTION
## What does this PR do?
This PR adds a new output, cache-hit, to the flutter-action. The cache-hit output indicates whether the cache was successfully hit during the setup process. This can help optimize workflows by conditionally executing subsequent steps based on cache status.

## Why is this change necessary?
In our project, we manage a monorepo using melos. As part of our CI/CD pipeline, we run melos bs (bootstrap) every time to set up dependencies and link packages. However, this can be redundant when the cache is already valid.

##  With the cache-hit output, we can:

- Avoid unnecessary executions of melos bs when the cache is valid.
- Reduce build times and resource usage.
- Enhance workflow efficiency.

## Example usage
Here’s how we plan to use the cache-hit output:

```yml
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout repository
        uses: actions/checkout@v4

      - name: Set up Flutter
        uses: subosito/flutter-action@v2
        id: flutter-action
        with:
          channel: stable
          cache: true

      - name: Conditionally run melos bootstrap
        if: steps.flutter-action.outputs.CACHE-HIT == 'false'
        run: melos bs

      - name: Continue with build
        run: flutter build apk


```