### PR TITLE
Fix PUB-CACHE-PATH output different to PUB_CACHE env variable

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -134,4 +134,5 @@ runs:
           -n '${{ steps.flutter-action.outputs.VERSION }}' \
           -a '${{ steps.flutter-action.outputs.ARCHITECTURE }}' \
           -c '${{ steps.flutter-action.outputs.CACHE-PATH }}' \
+          -d '${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}' \
           ${{ steps.flutter-action.outputs.CHANNEL }}


### PR DESCRIPTION
When passing a custom `pub-cache-path` the `PUB_CACHE` env variable would still point to the default value.