### PR TITLE
Remove restore-keys from caching

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -113,8 +113,6 @@ runs:
       with:
         path: ${{ steps.flutter-action.outputs.CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.CACHE-KEY }}
-        restore-keys: |
-          ${{ steps.flutter-action.outputs.CACHE-KEY }}
 
     - name: Cache pub dependencies
       uses: actions/cache@v4
@@ -122,9 +120,6 @@ runs:
       with:
         path: ${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}-${{ hashFiles('**/pubspec.lock') }}
-        restore-keys: |
-          ${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}-${{ hashFiles('**/pubspec.lock') }}
-          ${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}
 
     - name: Run setup script
       shell: bash


### PR DESCRIPTION
As mentioned in open issue #319, the `restore-keys` specified within `action.yaml` leads to some unpredictable behaviour; a `pub get` cache-miss could result in a _different_ hashed lock cache to be returned instead. In our experience, this has caused pipelines to fail, as the codebase is relying on packages which are not present in the pub cache. As @rolandmosimann recommends, I feel this behaviour should be removed, to fix this problem.

As a result, this PR removes the misleading `restore-key` on `pub get` caching, as well as the unnecessary declaration of a `restore-key` matching exactly the `key`. Let me know if you've got any questions 😄 