### PR TITLE
perf: Only install yq on Windows if used

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ steps:
 >
 > Using `flutter-version-file` requires [`yq`](https://github.com/mikefarah/yq),
 > which is not pre-installed in `windows` runners. Fortunately, since version
-> 2.18.0, this action installs `yq` automatically, so no action is required from
-> you.
+> 2.18.0, this action installs `yq` automatically if `flutter-version-file`
+> is specified, so no action is required from you.
 
 ### Use latest release for particular channel
 

--- a/action.yaml
+++ b/action.yaml
@@ -80,11 +80,12 @@ outputs:
 runs:
   using: composite
   steps:
-    # This is a cross-platform composite action that needs yq.
+    # This is a cross-platform composite action that needs yq in order to parse
+    # the pubspec.yaml file.
     # It's not preinstalled on Windows runners.
     # See https://github.com/actions/runner-images/issues/7443#issuecomment-1514597691
     - name: Make yq tool available on Windows runners
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && inputs.flutter-version-file != ''
       run: choco install yq
       shell: bash
 


### PR DESCRIPTION
The `yq` install on GitHub Windows runners is really slow. But it is only needed when `flutter-version-file` is specified. This PR makes it conditional so that it is only installed when this parameter is set.

Closes #361 
