### PR TITLE
Add cache hit outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ steps:
       echo ARCHITECTURE=${{ steps.flutter-action.outputs.ARCHITECTURE }}
       echo PUB-CACHE-PATH=${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
       echo PUB-CACHE-KEY=${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}
+      echo CACHE-HIT=${{ steps.flutter-action.outputs.CACHE-HIT }}
 ```
 
 If you don't need to install Flutter and just want the outputs, you can use the
@@ -361,6 +362,7 @@ steps:
       echo ARCHITECTURE=${{ steps.flutter-action.outputs.ARCHITECTURE }}
       echo PUB-CACHE-PATH=${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
       echo PUB-CACHE-KEY=${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}
+      echo CACHE-HIT=${{ steps.flutter-action.outputs.CACHE-HIT }}
     shell: bash
 ```
 [Alif Rachmawadi]: https://github.com/subosito

--- a/README.md
+++ b/README.md
@@ -319,12 +319,13 @@ dynamic values:
 
 ### Using cache outputs
 
-Note: `PUB-CACHE-HIT` and `CACHE-HIT` directly use the `cache-hit` output from `actions/cache@v4`, which is the following:
+> [!NOTE]
+> `PUB-CACHE-HIT` and `CACHE-HIT` directly use the `cache-hit` output from `actions/cache@v4`, which is the following:
 > - `cache-hit` - A string value to indicate an exact match was found for the key.
 >   - If there's a cache hit, this will be 'true' or 'false' to indicate if there's an exact match for `key`.
 >   - If there's a cache miss, this will be an empty string.
 
-Example usage (inspired by [actions/cache@v4](https://github.com/actions/cache?tab=readme-ov-file#skipping-steps-based-on-cache-hit) and [#346](https://github.com/subosito/flutter-action/pull/346)) to skip `melos bootstrap` if there was a pub cache hit:
+Example usage (inspired by [actions/cache@v4](https://github.com/actions/cache/blob/c45d39173a637a28edbd526cb160189cc4e84f5a/README.md#skipping-steps-based-on-cache-hit) and [#346](https://github.com/subosito/flutter-action/pull/346)) to skip `melos bootstrap` if there was a pub cache hit:
 
 ```
 steps:

--- a/README.md
+++ b/README.md
@@ -317,6 +317,37 @@ dynamic values:
 - `:hash:`
 - `:sha256:`
 
+### Using cache outputs
+
+Note: `PUB-CACHE-HIT` and `CACHE-HIT` directly use the `cache-hit` output from `actions/cache@v4`, which is the following:
+> - `cache-hit` - A string value to indicate an exact match was found for the key.
+>   - If there's a cache hit, this will be 'true' or 'false' to indicate if there's an exact match for `key`.
+>   - If there's a cache miss, this will be an empty string.
+
+Example usage (inspired by [actions/cache@v4](https://github.com/actions/cache?tab=readme-ov-file#skipping-steps-based-on-cache-hit) and [#346](https://github.com/subosito/flutter-action/pull/346)) to skip `melos bootstrap` if there was a pub cache hit:
+
+```
+steps:
+  - name: Checkout repository
+    uses: actions/checkout@v4
+
+  - name: Set up Flutter
+    uses: subosito/flutter-action@v2
+    id: flutter-action
+    with:
+      channel: stable
+      cache: true
+
+  - name: Conditionally run melos bootstrap
+    if: steps.flutter-action.outputs.PUB-CACHE-HIT != 'true'
+    run: melos bootstrap
+
+  - name: Continue with build
+    run: flutter build apk
+```
+
+## Outputs
+
 Use outputs from `flutter-action`:
 
 ```yaml
@@ -339,6 +370,7 @@ steps:
       echo PUB-CACHE-PATH=${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
       echo PUB-CACHE-KEY=${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}
       echo CACHE-HIT=${{ steps.flutter-action.outputs.CACHE-HIT }}
+      echo PUB-CACHE-HIT=${{ steps.flutter-action.outputs.PUB-CACHE-HIT }}
 ```
 
 If you don't need to install Flutter and just want the outputs, you can use the
@@ -363,7 +395,10 @@ steps:
       echo PUB-CACHE-PATH=${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
       echo PUB-CACHE-KEY=${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}
       echo CACHE-HIT=${{ steps.flutter-action.outputs.CACHE-HIT }}
+      echo PUB-CACHE-HIT=${{ steps.flutter-action.outputs.PUB-CACHE-HIT }}
     shell: bash
 ```
-[Alif Rachmawadi]: https://github.com/subosito
-[Bartek Pacia]: https://github.com/bartekpacia
+
+[Alif Rachmawadi](https://github.com/subosito)
+
+[Bartek Pacia](https://github.com/bartekpacia)

--- a/action.yaml
+++ b/action.yaml
@@ -77,10 +77,10 @@ outputs:
     value: "${{ steps.flutter-action.outputs.GIT_SOURCE }}"
     description: Git source of Flutter SDK repository to clone
   CACHE-HIT:
-    value: "${{ steps.cache-hit-flutter.outputs.cache-hit }}"
+    value: "${{ steps.cache-flutter.outputs.cache-hit }}"
     description: "`true` if the flutter cache was a hit"
   PUB-CACHE-HIT:
-    value: "${{ steps.cache-hit-pub.outputs.cache-hit }}"
+    value: "${{ steps.cache-pub.outputs.cache-hit }}"
     description: "`true` if the pub cache was a hit"
 
 runs:
@@ -121,11 +121,6 @@ runs:
       with:
         path: ${{ steps.flutter-action.outputs.CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.CACHE-KEY }}
-    
-    - name: Set flutter cache hit outputs
-      id: cache-hit-flutter
-      shell: bash
-      run: echo "cache-hit=${{ steps.cache-flutter.outputs.cache-hit }}" >> "$GITHUB_OUTPUT"
 
     - name: Cache pub dependencies
       uses: actions/cache@v4
@@ -134,11 +129,6 @@ runs:
       with:
         path: ${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}-${{ hashFiles('**/pubspec.lock') }}
-
-    - name: Set pub cache hit outputs
-      id: cache-hit-pub
-      shell: bash
-      run: echo "pub-cache-hit=${{ steps.cache-pub.outputs.cache-hit }}" >> "$GITHUB_OUTPUT"
 
     - name: Run setup script
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -77,8 +77,11 @@ outputs:
     value: "${{ steps.flutter-action.outputs.GIT_SOURCE }}"
     description: Git source of Flutter SDK repository to clone
   CACHE-HIT:
+    value: "${{ steps.cache-hit-flutter.outputs.cache-hit }}"
+    description: "`true` if the flutter cache was a hit"
+  PUB-CACHE-HIT:
     value: "${{ steps.cache-hit-pub.outputs.cache-hit }}"
-    description: Whether the Pub cache was a hit
+    description: "`true` if the pub cache was a hit"
 
 runs:
   using: composite
@@ -112,11 +115,17 @@ runs:
           ${{ inputs.channel }}
 
     - name: Cache Flutter
+      id: cache-flutter
       uses: actions/cache@v4
       if: ${{ inputs.cache == 'true' }}
       with:
         path: ${{ steps.flutter-action.outputs.CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.CACHE-KEY }}
+    
+    - name: Set flutter cache hit outputs
+      id: cache-hit-flutter
+      shell: bash
+      run: echo "cache-hit=${{ steps.cache-flutter.outputs.cache-hit }}" >> "$GITHUB_OUTPUT"
 
     - name: Cache pub dependencies
       uses: actions/cache@v4
@@ -129,7 +138,7 @@ runs:
     - name: Set pub cache hit outputs
       id: cache-hit-pub
       shell: bash
-      run: echo "cache-hit=${{ steps.cache-pub.outputs.cache-hit }}" >> "$GITHUB_OUTPUT"
+      run: echo "pub-cache-hit=${{ steps.cache-pub.outputs.cache-hit }}" >> "$GITHUB_OUTPUT"
 
     - name: Run setup script
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -76,6 +76,9 @@ outputs:
   GIT_SOURCE:
     value: "${{ steps.flutter-action.outputs.GIT_SOURCE }}"
     description: Git source of Flutter SDK repository to clone
+  CACHE-HIT:
+    value: "${{ steps.cache-hit-pub.outputs.cache-hit }}"
+    description: Whether the Pub cache was a hit
 
 runs:
   using: composite
@@ -117,10 +120,16 @@ runs:
 
     - name: Cache pub dependencies
       uses: actions/cache@v4
+      id: cache-pub
       if: ${{ inputs.cache == 'true' }}
       with:
         path: ${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}-${{ hashFiles('**/pubspec.lock') }}
+
+    - name: Set pub cache hit outputs
+      id: cache-hit-pub
+      shell: bash
+      run: echo "cache-hit=${{ steps.cache-pub.outputs.cache-hit }}" >> "$GITHUB_OUTPUT"
 
     - name: Run setup script
       shell: bash


### PR DESCRIPTION
This PR addresses the changes requested in #346 from earlier this year, as I also would like to be able to use this feature.

It adds 2 new outputs: CACHE-HIT and PUB-CACHE-HIT. These just pass along the `cache-hit` output from `actions/cache@v4` for the `cache-flutter` and `cache-pub` steps. These can be used for increasing workflow efficiency through steps like conditionally installing dependencies when the cache is invalid. The README is also updated with example usage to skip `melos bootstrap` if `PUB-CACHE-HIT` was not `true`.

I tested the outputs here: https://github.com/beninato8-forks/flutter-action/actions/runs/15627281250/job/44023816175

```
Cache restored successfully
Cache restored from key: flutter-linux-stable-3.27.4-x64-d8a9f9a52e5af486f80d932e838ee93861ffd863
...
Cache restored successfully
Cache restored from key: flutter-pub-linux-stable-3.27.4-x64-d8a9f9a52e5af486f80d932e838ee93861ffd863-
...
Cache Hit: true
Pub Cache Hit: true
```

Output from the following steps (after a previous run was cached):
```
- name: Flutter Action 1
  uses: ./
  id: flutter-action-1
  with:
    flutter-version: '3.27.x'
    channel: 'stable'
    cache: true

- name: Print Action Outputs 1
  run: |
    echo "Cache Hit: ${{ steps.flutter-action-1.outputs.CACHE-HIT }}"
    echo "Pub Cache Hit: ${{ steps.flutter-action-1.outputs.PUB-CACHE-HIT }}"
```

This PR closes #346 