### PR TITLE
Pin actions/cache to v4.3.0 commit hash

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -116,14 +116,14 @@ runs:
 
     - name: Cache Flutter
       id: cache-flutter
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       if: ${{ inputs.cache == 'true' }}
       with:
         path: ${{ steps.flutter-action.outputs.CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.CACHE-KEY }}
 
     - name: Cache pub dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: cache-pub
       if: ${{ inputs.cache == 'true' }}
       with:


### PR DESCRIPTION
issue: https://github.com/subosito/flutter-action/issues/371

This PR pins `actions/cache` to the v4.3.0 commit hash (Ref: https://github.com/actions/cache/releases/tag/v4.3.0).
This resolves failures when the 'Enforce SHA pinning' policy is enabled in an organization.

This change should not affect the action's runtime behavior, as it only updates the reference from a tag to a specific commit SHA.

(Note: I used [pinact](https://github.com/suzuki-shunsuke/pinact) for pinning.)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned Flutter action cache dependencies to specific versions for consistent resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->