### PR TITLE
Pin actions/cache to commit hash for security

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -116,14 +116,14 @@ runs:
 
     - name: Cache Flutter
       id: cache-flutter
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       if: ${{ inputs.cache == 'true' }}
       with:
         path: ${{ steps.flutter-action.outputs.CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.CACHE-KEY }}
 
     - name: Cache pub dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: cache-pub
       if: ${{ inputs.cache == 'true' }}
       with:


### PR DESCRIPTION
- Pin `actions/cache@v4` to specific commit hash (`0057852bfaa89a56745cba8c7296529d2fc39830` = v4.3.0)
- Mitigate supply chain attack risks by avoiding mutable tag references

This setting need for `Require actions to be pinned to a full-length commit SHA` setting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned build cache actions to specific commit references for enhanced build consistency and security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->