### PR TITLE
Add separate pub-cache boolean flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,12 +323,30 @@ steps:
       channel: stable
       cache: true
       # optional parameters follow
+      pub-cache: true # optional, defaults to empty (falls back to cache value for backward compatibility)
       cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
       cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
       pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache of dart pub get dependencies
       pub-cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
   - run: flutter --version
 ```
+
+> [!NOTE]
+>
+> The `cache` and `pub-cache` inputs are independent and control different caches:
+> - `cache: true` - Caches the Flutter SDK installation
+> - `pub-cache: true` - Caches Dart pub dependencies
+> - `pub-cache: false` - Disables pub dependency caching
+> 
+> **Backward Compatibility:** When `pub-cache` is not specified (empty), it falls back to the `cache` value.
+> This means existing workflows with `cache: true` will automatically cache both Flutter SDK and pub dependencies.
+> 
+> You can use them in any combination:
+> - Both enabled: `cache: true` (pub-cache will default to true for backward compatibility)
+> - Both enabled explicitly: `cache: true` and `pub-cache: true`
+> - Only Flutter SDK: `cache: true` and `pub-cache: false`
+> - Only pub dependencies: `cache: false` and `pub-cache: true` for self-hosted runners
+> - Neither: `cache: false` and `pub-cache: false` (or omit both)
 
 Note: `cache-key`, `pub-cache-key`, and `cache-path` have support for several
 dynamic values:

--- a/action.yaml
+++ b/action.yaml
@@ -34,6 +34,10 @@ inputs:
     description: Flutter SDK cache path
     required: false
     default: ""
+  pub-cache:
+    description: Cache the Dart pub dependencies
+    required: false
+    default: ""
   pub-cache-key:
     description: Identifier for the Dart .pub-cache cache
     required: false
@@ -125,7 +129,7 @@ runs:
     - name: Cache pub dependencies
       uses: actions/cache@v5
       id: cache-pub
-      if: ${{ inputs.cache == 'true' }}
+      if: ${{ (inputs.pub-cache == '' && inputs.cache == 'true') || inputs.pub-cache == 'true' }}
       with:
         path: ${{ steps.flutter-action.outputs.PUB-CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}-${{ hashFiles('**/pubspec.lock') }}


### PR DESCRIPTION
This allows to selectively enabled/disable SDK & pub dependency caching.
Uses backwards compatible default if only `cache: true` is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `pub-cache` configuration parameter to independently control Dart pub dependency caching; when unspecified it falls back to the existing `cache` behavior.
* **Documentation**
  * Updated docs to explain `pub-cache` behavior, usage scenarios, defaults, and dynamic value references.
* **Chores**
  * CI matrix updated to use macOS-14 in relevant test jobs; cache step now honors `pub-cache` when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->