### PR TITLE
Simplify extraction of zip files

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -227,7 +227,7 @@ if [ ! -x "$CACHE_PATH/flutter/bin/flutter" ]; then
 		git clone -b "$CHANNEL" "$GIT_SOURCE" "$CACHE_PATH/flutter"
 		if [ "$VERSION" != "any" ]; then
 			git config --global --add safe.directory "$CACHE_PATH/flutter"
-			(cd "$CACHE_PATH" && git checkout "$VERSION")
+			(cd "$CACHE_PATH/flutter" && git checkout "$VERSION")
 		fi
 	else
 		archive_url=$(echo "$VERSION_MANIFEST" | jq -r '.archive')


### PR DESCRIPTION
Refactor unzip/tar commands to directly extract to target directory without stripping components.
By keeping the /flutter directory from inside the archive, we avoid having to use a temp directory and move afterwards.

Fixes #378 

This works fine but not exactly sure how it fares with existing caches.
The change might warrant a v3 release.