### PR TITLE
Harden setup.sh and update README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ steps:
       cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
       cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
       pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache of dart pub get dependencies
-      pub-cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
+      pub-cache-path: "default" # optional, change this to specify the cache path (default: $HOME/.pub-cache)
   - run: flutter --version
 ```
 
@@ -390,6 +390,7 @@ steps:
       echo PUB-CACHE-KEY=${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}
       echo CACHE-HIT=${{ steps.flutter-action.outputs.CACHE-HIT }}
       echo PUB-CACHE-HIT=${{ steps.flutter-action.outputs.PUB-CACHE-HIT }}
+      echo GIT_SOURCE=${{ steps.flutter-action.outputs.GIT_SOURCE }}
 ```
 
 If you don't need to install Flutter and just want the outputs, you can use the
@@ -415,6 +416,7 @@ steps:
       echo PUB-CACHE-KEY=${{ steps.flutter-action.outputs.PUB-CACHE-KEY }}
       echo CACHE-HIT=${{ steps.flutter-action.outputs.CACHE-HIT }}
       echo PUB-CACHE-HIT=${{ steps.flutter-action.outputs.PUB-CACHE-HIT }}
+      echo GIT_SOURCE=${{ steps.flutter-action.outputs.GIT_SOURCE }}
     shell: bash
 ```
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 
 check_command() {
 	command -v "$1" >/dev/null 2>&1
@@ -45,7 +45,7 @@ download_archive() {
 	archive_name=$(basename "$1")
 	archive_local="$RUNNER_TEMP/$archive_name"
 
-	curl --connect-timeout 15 --retry 5 "$archive_url" >"$archive_local"
+	curl -fL --connect-timeout 15 --retry 5 "$archive_url" >"$archive_local"
 
 	mkdir -p "$2"
 
@@ -113,8 +113,8 @@ if [ -n "$VERSION_FILE" ]; then
 	VERSION="$(yq eval '.environment.flutter' "$VERSION_FILE")"
 fi
 
-ARR_CHANNEL=("${@:$OPTIND:1}")
-CHANNEL="${ARR_CHANNEL[0]:-}"
+shift $((OPTIND - 1))
+CHANNEL="${1:-}"
 
 [ -z "$CHANNEL" ] && CHANNEL=stable
 [ -z "$VERSION" ] && VERSION=any
@@ -144,7 +144,7 @@ fi
 if [ "$TEST_MODE" = true ]; then
 	RELEASE_MANIFEST=$(cat "$(dirname -- "${BASH_SOURCE[0]}")/test/$MANIFEST_JSON_PATH")
 else
-	RELEASE_MANIFEST=$(curl --silent --connect-timeout 15 --retry 5 "$MANIFEST_URL")
+	RELEASE_MANIFEST=$(curl -sfL --connect-timeout 15 --retry 5 "$MANIFEST_URL")
 fi
 
 if [ "$CHANNEL" = "master" ] || [ "$CHANNEL" = "main" ]; then
@@ -198,6 +198,7 @@ if [ "$PRINT_ONLY" = true ]; then
 		echo "CACHE-PATH=$CACHE_PATH"
 		echo "PUB-CACHE-KEY=$PUB_CACHE_KEY"
 		echo "PUB-CACHE-PATH=$PUB_CACHE"
+		echo "GIT_SOURCE=$GIT_SOURCE"
 		exit 0
 	fi
 
@@ -210,6 +211,7 @@ if [ "$PRINT_ONLY" = true ]; then
 		echo "CACHE-PATH=$CACHE_PATH"
 		echo "PUB-CACHE-KEY=$PUB_CACHE_KEY"
 		echo "PUB-CACHE-PATH=$PUB_CACHE"
+		echo "GIT_SOURCE=$GIT_SOURCE"
 	} >>"${GITHUB_OUTPUT:-/dev/null}"
 
 	exit 0


### PR DESCRIPTION
- Added 'set -o pipefail' to setup.sh for better error propagation
- Hardened curl calls with -fL for robust downloads and redirect handling
- Simplified positional argument parsing using 'shift'
- Added 'GIT_SOURCE' to environment and test mode outputs
- Fixed overlapping 'pub-cache-path' example in README.md
- Documented 'GIT_SOURCE' output in README.md examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GIT_SOURCE is now included in exported outputs for downstream consumption.

* **Bug Fixes**
  * Improved error handling for HTTP operations and manifest retrieval.

* **Improvements**
  * Enhanced default variable initialization with sensible defaults.
  * Updated default cache path configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->