### PR TITLE
Upgrade actions/cache to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,11 @@ jobs:
 
 Integration with [`actions/cache`](https://github.com/actions/cache):
 
+> [!IMPORTANT]
+> `subosito/flutter-action` now uses `actions/cache@v5` internally. If you use
+> self-hosted runners, make sure they are updated to Actions Runner
+> `2.327.1` or newer before enabling cache support.
+
 ```yaml
 steps:
   - name: Clone repository
@@ -338,12 +343,12 @@ dynamic values:
 ### Using cache outputs
 
 > [!NOTE]
-> `PUB-CACHE-HIT` and `CACHE-HIT` directly use the `cache-hit` output from `actions/cache@v4`, which is the following:
+> `PUB-CACHE-HIT` and `CACHE-HIT` directly use the `cache-hit` output from `actions/cache@v5`, which is the following:
 > - `cache-hit` - A string value to indicate an exact match was found for the key.
 >   - If there's a cache hit, this will be 'true' or 'false' to indicate if there's an exact match for `key`.
 >   - If there's a cache miss, this will be an empty string.
 
-Example usage (inspired by [actions/cache@v4](https://github.com/actions/cache/blob/c45d39173a637a28edbd526cb160189cc4e84f5a/README.md#skipping-steps-based-on-cache-hit) and [#346](https://github.com/subosito/flutter-action/pull/346)) to skip `melos bootstrap` if there was a pub cache hit:
+Example usage (inspired by [actions/cache@v5](https://github.com/actions/cache/blob/v5/README.md#skipping-steps-based-on-cache-hit) and [#346](https://github.com/subosito/flutter-action/pull/346)) to skip `melos bootstrap` if there was a pub cache hit:
 
 ```
 steps:

--- a/action.yaml
+++ b/action.yaml
@@ -116,14 +116,14 @@ runs:
 
     - name: Cache Flutter
       id: cache-flutter
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       if: ${{ inputs.cache == 'true' }}
       with:
         path: ${{ steps.flutter-action.outputs.CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.CACHE-KEY }}
 
     - name: Cache pub dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: cache-pub
       if: ${{ inputs.cache == 'true' }}
       with:


### PR DESCRIPTION
## Summary
- upgrade the composite action cache steps from Actions/cache@v4 to Actions/cache@v5
- update the README cache output references to Actions/cache@v5
- document the minimum self-hosted runner version required for the cache upgrade

Closes #384