### PR TITLE
Remove macos-13 (Intel) runner from CI

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -30,7 +30,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
-          - macos-13
         channel: [stable, beta, master]
         dry-run: [true, false]
         git-source:
@@ -80,7 +79,7 @@ jobs:
     strategy:
       matrix:
         operating-system:
-          [ubuntu-latest, windows-latest, macos-latest, macos-13]
+          [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
Closes #387

`macos-13` was retired by GitHub in December 2025 and no longer works. Intel-based macOS runners are being phased out entirely, with only expensive `*-large` variants remaining as alternatives.

This removes `macos-13` from the runner matrix in both `test_channel` and `test_cache` jobs.

Made with [Cursor](https://cursor.com)