### PR TITLE
chore: pin used actions to full length commit sha

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -120,14 +120,14 @@ runs:
 
     - name: Cache Flutter
       id: cache-flutter
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       if: ${{ inputs.cache == 'true' }}
       with:
         path: ${{ steps.flutter-action.outputs.CACHE-PATH }}
         key: ${{ steps.flutter-action.outputs.CACHE-KEY }}
 
     - name: Cache pub dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       id: cache-pub
       if: ${{ (inputs.pub-cache == '' && inputs.cache == 'true') || inputs.pub-cache == 'true' }}
       with:


### PR DESCRIPTION
Resolves #397

Why is this important:
Reading on more emerging supply chain attacks tags are a moving target. They can be deleted and created on a new commit with the infected code.
