### PR TITLE
Enforce SHA pinning templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/enforce-sha-pinning.md
+++ b/.github/ISSUE_TEMPLATE/enforce-sha-pinning.md
@@ -1,0 +1,13 @@
+---
+name: Enforce SHA pinning
+about: Note that this feature request is not supported in this repository.
+title: "[Declined] Request: Enforce SHA pinning"
+labels: wontfix
+assignees: ''
+---
+
+Thank you for being so interested! However, we do not support or accept requests to enforce SHA pinning in this repository. 
+
+We have discussed this previously and decided against implementing it. Please see #393 for more context on this technical decision. 
+
+**Please do not submit this issue, as it will be immediately closed.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+**Policy:** Pull requests to enforce SHA pinning are not supported in this repository and will be closed. For context on why we do not use this feature, please refer to #393.
+
+<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
+- [ ] This pull request isn't about enforcing SHA pinning.


### PR DESCRIPTION
https://github.com/subosito/flutter-action/pull/393#issuecomment-4112369217

> I'm starting to think about creating a dedicated PR template for commit SHA pinning PRs, which simply says: `STOP`.

What started as a joke now becomes a hard reality, given the crazy amount of issues and PRs on this topic.