### PR TITLE
Allow arm64 via git

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -79,7 +79,13 @@ jobs:
     strategy:
       matrix:
         operating-system:
-          [ubuntu-latest, windows-latest, windows-11-arm, macos-latest]
+          [
+            ubuntu-latest,
+            ubuntu-26.04-arm,
+            windows-latest,
+            windows-11-arm,
+            macos-latest,
+          ]
 
     steps:
       - name: Clone repository

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       matrix:
         operating-system:
-          [ubuntu-latest, windows-latest, macos-latest]
+          [ubuntu-latest, windows-latest, windows-11-arm, macos-latest]
 
     steps:
       - name: Clone repository
@@ -87,7 +87,7 @@ jobs:
       - uses: ./
         with:
           channel: stable
-          flutter-version: 3.10.6
+          flutter-version: 3.44.x
           cache: true
       - run: dart --version
         shell: bash
@@ -99,7 +99,7 @@ jobs:
 
     strategy:
       matrix:
-        operating-system: [ubuntu-latest]
+        operating-system: [ubuntu-latest, windows-11-arm]
 
     steps:
       - name: Clone repository
@@ -142,6 +142,27 @@ jobs:
           echo ARCHITECTURE=${{ steps.flutter-action.outputs.ARCHITECTURE }}
         shell: bash
       - run: flutter --version
+        shell: bash
+
+  test_print_output_win_arm64:
+    runs-on: windows-11-arm
+
+    # These calls to setup.sh sepcify the -t flag, which enables test mode.
+    # Test mode uses hardcoded Flutter release manifests from test/ directory.
+
+    steps:
+      - name: Install dependencies
+        run: choco install yq
+        shell: powershell
+      - name: Clone repository
+        uses: actions/checkout@v6
+      - run: ./setup.sh -t -p -f test/pubspec.yaml   | grep '3.3.10'
+        shell: bash
+      - run: ./setup.sh -t -p                        | grep 'stable'
+        shell: bash
+      - run: ./setup.sh -t -p                        | grep 'any'
+        shell: bash
+      - run: ./setup.sh -t -p                        | grep 'arm64'
         shell: bash
 
   test_print_output_x64:

--- a/setup.sh
+++ b/setup.sh
@@ -28,8 +28,9 @@ filter_by_version() {
 	jq --arg version "$1" '.[].version |= gsub("^v"; "") | (if $version == "any" then .[0] else (map(select(.version == $version or (.version | startswith(($version | sub("\\.x$"; "")) + ".")) and .version != $version)) | .[0]) end)'
 }
 
-not_found_error() {
-	echo "Unable to determine Flutter version for channel: $1 version: $2 architecture: $3"
+not_found_warning() {
+	echo "Unable to determine Flutter version for channel: $1 version: $2 architecture: $3 via the JSON manifest $4"
+	echo "Falling back to git clone \"$5\", which may be slower."
 }
 
 transform_path() {
@@ -154,18 +155,6 @@ else
 	RELEASE_MANIFEST=$(curl --silent --connect-timeout 15 --retry 5 "$MANIFEST_URL")
 fi
 
-if [ "$CHANNEL" = "master" ] || [ "$CHANNEL" = "main" ]; then
-	VERSION_MANIFEST="{\"channel\":\"$CHANNEL\",\"version\":\"$VERSION\",\"dart_sdk_arch\":\"$ARCH\",\"hash\":\"$CHANNEL\",\"sha256\":\"$CHANNEL\"}"
-else
-	VERSION_MANIFEST=$(echo "$RELEASE_MANIFEST" | filter_by_channel "$CHANNEL" | filter_by_arch "$ARCH" | filter_by_version "$VERSION")
-fi
-
-case "$VERSION_MANIFEST" in
-*null*)
-	not_found_error "$CHANNEL" "$VERSION" "$ARCH"
-	exit 1
-	;;
-esac
 
 expand_key() {
 	version_channel=$(echo "$VERSION_MANIFEST" | jq -r '.channel')
@@ -183,6 +172,13 @@ expand_key() {
 
 	echo "$expanded_key"
 }
+
+VERSION_MANIFEST=$(echo "$RELEASE_MANIFEST" | filter_by_channel "$CHANNEL" | filter_by_arch "$ARCH" | filter_by_version "$VERSION")
+case "$VERSION_MANIFEST" in
+*null*)
+	VERSION_MANIFEST="{\"channel\":\"$CHANNEL\",\"version\":\"$VERSION\",\"dart_sdk_arch\":\"$ARCH\",\"hash\":\"$CHANNEL\",\"sha256\":\"$CHANNEL\"}"
+	;;
+esac
 
 CACHE_KEY=$(expand_key "$CACHE_KEY")
 PUB_CACHE_KEY=$(expand_key "$PUB_CACHE_KEY")
@@ -223,14 +219,15 @@ if [ "$PRINT_ONLY" = true ]; then
 fi
 
 if [ ! -x "$CACHE_PATH/flutter/bin/flutter" ]; then
-	if [ "$CHANNEL" = "master" ] || [ "$CHANNEL" = "main" ]; then
+	archive_url=$(echo "$VERSION_MANIFEST" | jq -r '.archive')
+	if [ -z "$archive_url" ] || [ "$archive_url" = "null" ]; then
+		not_found_warning "$CHANNEL" "$VERSION" "$ARCH" "$MANIFEST_URL" "$GIT_SOURCE"
 		git clone -b "$CHANNEL" "$GIT_SOURCE" "$CACHE_PATH/flutter"
 		if [ "$VERSION" != "any" ]; then
 			git config --global --add safe.directory "$CACHE_PATH/flutter"
 			(cd "$CACHE_PATH/flutter" && git checkout "$VERSION")
 		fi
 	else
-		archive_url=$(echo "$VERSION_MANIFEST" | jq -r '.archive')
 		download_archive "$archive_url" "$CACHE_PATH"
 	fi
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -225,7 +225,7 @@ if [ ! -x "$CACHE_PATH/flutter/bin/flutter" ]; then
 		git clone -b "$CHANNEL" "$GIT_SOURCE" "$CACHE_PATH/flutter"
 		if [ "$VERSION" != "any" ]; then
 			git config --global --add safe.directory "$CACHE_PATH/flutter"
-			(cd "$CACHE_PATH/flutter" && git checkout "$VERSION")
+			(cd "$CACHE_PATH/flutter" && git checkout "$VERSION" && flutter doctor)
 		fi
 	else
 		download_archive "$archive_url" "$CACHE_PATH"

--- a/setup.sh
+++ b/setup.sh
@@ -225,7 +225,18 @@ if [ ! -x "$CACHE_PATH/flutter/bin/flutter" ]; then
 		git clone -b "$CHANNEL" "$GIT_SOURCE" "$CACHE_PATH/flutter"
 		if [ "$VERSION" != "any" ]; then
 			git config --global --add safe.directory "$CACHE_PATH/flutter"
-			(cd "$CACHE_PATH/flutter" && git checkout "$VERSION" && flutter doctor)
+			# Sanitize VERSION, as it could be a pattern like 3.15.x
+			GIT_PATTERN="${VERSION/%x/*}"
+			if [ "$VERSION" != "$GIT_PATTERN" ]; then
+			  # We cannot simply checkout as we have a pattern, so we need to find the right ref that matches the pattern
+			  GIT_REF=$(git -C "$CACHE_PATH/flutter" tag -l "$GIT_PATTERN" --sort=-v:refname | grep -v "pre" | head -n 1)
+			  if [ -z "$GIT_REF" ]; then
+			    echo "No git ref found for pattern $GIT_PATTERN"
+			    exit 1
+			  fi
+			  VERSION="$GIT_REF"
+			fi
+			(cd "$CACHE_PATH/flutter" && git checkout "$VERSION" && ./bin/flutter doctor)
 		fi
 	else
 		download_archive "$archive_url" "$CACHE_PATH"


### PR DESCRIPTION
Flutter 3.44 was recently announced with stable support for Windows on ARM64 hosts, meaning it's possible to compile native applications for WoA on such hosts, and there are pre-built binaries for the flutter tools and SDK available. Thus we don't have to be on the master channel to use Flutter on Windows on ARM64. Yet, as reported in issues like #345 , this action always fails to set up Flutter on such devices because the JSON manifests used to compose the URLs to the bundled SDK releases from the Flutter archive are not available for Windows and Linux on ARM64. 

With this PR I propose to fallback to Git when SDK releases are not found in the JSON manifests. That's a pessimisation for the unhappy paths (for which there is no SDK actually) as instead of failing fast we go to a Git clone first, yet I suspect we should optimize for the happy paths, as people relying on the action are likely already running the same Flutter versions locally. 

I sprinkled some additional tests on those platforms, but I'd be happy to iterate on them with further guidance on the specific needs of the project.

---

**Policy:** Pull requests to enforce SHA pinning are not supported in this repository and will be closed. For context on why we do not use this feature, please refer to #393.

<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
- [x] This pull request isn't about enforcing SHA pinning.

---

I hope this PR is welcome to maintainers and the broader community.